### PR TITLE
Update Xavier University posting

### DIFF
--- a/_includes/deadlines-23.md
+++ b/_includes/deadlines-23.md
@@ -27,7 +27,6 @@
 | [Whitman College](#whitman) | Walla Walla, WA. USA | 10/18/2023 |
 | [James Madison University](#jmu) | Harrisonburg, VA. USA | 10/20/2023 |
 | [St. Lawrence University](#stlawu) | Canton, NY. USA | 10/22/2023 |
-| [Xavier University](#xavier) | Cincinnati, OH. USA | 10/23/2023 |
 | [Barnard College](#barnard) | New York, NY. USA | 10/27/2023 |
 | [Franklin & Marshall College](#fnm) | Lancaster, PA. USA | 10/31/2023 |
 | [Simmons University](#simmons) | Boston, MA. USA | 10/31/2023 |
@@ -40,3 +39,4 @@
 | [Union College](#union) | Schenectady, NY. USA | 1/31/2024 |
 | [College of the Holy Cross #2](#holycross-2) | Worcester, MA. USA | 2/1/2024 |
 | [College of Charleston](#cofc1) | Charleston, SC. USA | 2/15/2024 |
+| [Xavier University](#xavier) | Cincinnati, OH. USA | 2/21/2024 |

--- a/_includes/descriptions-23.md
+++ b/_includes/descriptions-23.md
@@ -514,12 +514,12 @@ _Excerpt_Barnard College invites applications for a tenure-track assistant profe
 ### Xavier University
 {: #xavier}
 
-_Excerpt_ The Department of Computer Science invites applications for two tenure-track positions, one at the assistant professor level and the other at open rank, starting Fall 2024. Applicants should have a Ph.D. in Computer Science or Computer Science Education; the degree should be completed by August 2024. Candidates should have an interest in helping grow a diverse and inclusive student community while teaching a variety of undergraduate courses, including their own specialty. Candidates must be committed to outstanding teaching in a liberal arts tradition of active learning, the development of a sustainable scholarly research program, and service consistent with Xavier’s Mission Statement. We are particularly interested in candidates whose activities encourage student participation in scholarly activities.
+_Excerpt_ The Department of Computer Science invites applications for an Assistant Professor tenure-track position, starting Fall 2024. Applicants should have a Ph.D. in Computer Science or Computer Science Education; the degree should be completed by August 2024. Candidates should have an interest in helping grow a diverse and inclusive student community while teaching a variety of undergraduate courses, including their own specialty. Candidates must be committed to outstanding teaching in a liberal arts tradition of active learning, the development of a sustainable scholarly research program, and service consistent with Xavier’s Mission Statement. We are particularly interested in candidates whose activities encourage student participation in scholarly activities.
 
-- Review of applications will begin on **October 23, 2023**
+- The deadline is **February 21, 2023**
 - Cincinnati, OH. USA.
 
-[Full Job Posting](https://academicjobsonline.org/ajo/jobs/26015){: .button-job}
+[Full Job Posting](https://academicjobsonline.org/ajo/jobs/27117){: .button-job}
 [_back to all deadlines_](#deadlines)
 
 ------------


### PR DESCRIPTION
Xavier is performing a second search, so last semester's entry in the deadlines file was moved to the end with an updated deadline, and the job description and link was updated.