### PR TITLE
Fixed anchor link for F&M

### DIFF
--- a/_includes/deadlines.md
+++ b/_includes/deadlines.md
@@ -18,5 +18,5 @@
 | [Wesleyan University](#wesleyan) | Middletown, CT. USA | 10/15/2024 |
 | [Richmond University](#richmond) | Richmond, VA. USA | 10/18/2024 | 
 | [Randolph-Macon College](#randolph) | Ashland, VA. USA | 10/21/2024 | 
-| [Franklin & Marshall College](#f&m) | Lancaster, PA. USA | 10/25/2024 |
+| [Franklin & Marshall College](#franklinmarshall) | Lancaster, PA. USA | 10/25/2024 |
 | [Williams College](#williams) | Williamstown, MA. USA | 11/08/2024 |

--- a/_includes/descriptions.md
+++ b/_includes/descriptions.md
@@ -64,7 +64,7 @@ _Excerpt_ Carleton College invites applications for a tenure-track position in c
 ------------
 
 ### Franklin & Marshall College
-{: #f&m}
+{: #franklinmarshall}
 
 _Excerpt_ Franklin & Marshall College invites applications for a tenure-track position in the Department of Computer Science beginning August 2025.  The rank will be Assistant Professor or Instructor depending on qualifications.  Applicants should possess or be close to completing a doctorate degree in Computer Science, or a related field.  Candidates must apply electronically via Interfolio: [http://apply.interfolio.com/153132](http://apply.interfolio.com/153132).  Individuals who need accommodation due to a disability in order to submit an application or to otherwise participate in the employment process should contact the department’s academic coordinator, Kelly Smith [kelly.smith@fandm.edu](kelly.smith@fandm.edu). 
 


### PR DESCRIPTION
Sorry for a second pull request so soon.

I noticed the F&M anchor link doesn't seem to be working on https://cs-pui.github.io/   The link from the deadlines section to the descriptions section works for every other school besides F&M.   I think the "&" in the anchor itself is the problem so I removed it.  I'm not 100% sure this will fix the link, since I don't know how to test this without pushing changes to the actual https://cs-pui.github.io/ website.

